### PR TITLE
Enable scalajs cross-compilation.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,6 @@
+// shadow sbt-scalajs' crossProject and CrossType from Scala.js 0.6.x
+import sbtcrossproject.CrossPlugin.autoImport.{crossProject, CrossType}
+
 organization := "tv.cntt"
 name         := "scaposer"
 version      := "1.11.1-SNAPSHOT"
@@ -9,9 +12,16 @@ scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked")
 javacOptions ++= Seq("-source", "1.8", "-target", "1.8")
 
 // Scala 2.11+ core does not include scala.util.parsing.combinator
-libraryDependencies += "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.2"
+libraryDependencies += "org.scala-lang.modules" %%% "scala-parser-combinators" % "1.1.2"
 
-libraryDependencies += "org.specs2" %% "specs2-core" % "4.6.0" % "test"
+libraryDependencies += "org.specs2" %%% "specs2-core" % "4.10.2" % "test"
 
-//https://github.com/scala/scala-parser-combinators/issues/197
-fork in Test := true
+lazy val scaposer = crossProject(JVMPlatform, JSPlatform)
+  .crossType(CrossType.Pure)
+
+lazy val scaposerJS = scaposer.js
+lazy val scaposerJVM = scaposer.jvm
+
+lazy val root = (project in file("."))
+  .aggregate(scaposerJS, scaposerJVM)
+  .settings(skip in publish := true)

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,3 @@
+install:
+   - sbt '++ publishM2'
+   - env SCALAJS_VERSION="0.6.32" sbt '++ publishM2'

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.18
+sbt.version=1.3.12

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,7 @@
 // Run sbt eclipse to create Eclipse project file
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "5.2.4")
+
+// http://www.scala-js.org/news/2020/02/25/announcing-scalajs-1.0.0/#cross-building-for-scalajs-06x-and-1x
+val scalaJSVersion = scala.util.Properties.envOrElse("SCALAJS_VERSION", "1.1.1")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")


### PR DESCRIPTION
Hi, @ngocdaothanh 

First of all, thanks for writing scaposer! We are trying to use it from an scalajs front-end application.

This pull request adds cross-compilations to latest scalajs stable release. Also upgraded the `specs2-core` dependency to match the latest published for scalajs compatibility.

Removed the `fork in Test := true` code from `build.sbt` since the issue  https://github.com/scala/scala-parser-combinators/issues/197 has already been solved in sbt `1.3.x`.

Added a `jitpack.yml` in order to be able to fetch artifacts for non-release versions (like this patch) by using [jitpack.io](https://jitpack.io/com/github/deal-engine/scaposer/6f99a22/build.log).